### PR TITLE
Add stooq fallback for GPW data

### DIFF
--- a/data_io.py
+++ b/data_io.py
@@ -11,6 +11,98 @@ WIG20_HC_TICKERS = ["PKN","KGH","PKO","PEO","PZU","PGE","CDR","ALE","DNP","LPP",
 MWIG40_HC_TICKERS = ["XTB","PLW","TEN","KRU","GPW","BDX","BHW","LWB","AMC","ASB","11B","CIG","MLG","STP","PKP","MAB","NEU","OPN","VRG","WPL","DOM","MRC","PHN","TIM","MFO","PBX","BRS","FTE","TOR","LVC","DNP"]
 SP500_FALLBACK = ["AAPL","MSFT","NVDA","GOOGL","GOOG","AMZN","META","BRK-B","AVGO","TSLA","UNH","LLY","XOM","JPM","V","JNJ","PG","MA","HD","COST","MRK","ABBV","PEP","KO","TMO","BAC","WMT","ADBE","NFLX","CRM","CSCO","INTC","QCOM","NKE","LIN","ACN","MCD","ORCL","TXN","AMD"]
 
+STOOQ_BASE_URLS = (
+    "https://stooq.pl",
+    "https://stooq.com",
+)
+
+STOOQ_INTERVAL_MAP = {
+    "1wk": "w",
+    "1mo": "m",
+    "3mo": "q",
+}
+
+
+def _yahoo_to_stooq_symbol(yahoo_ticker: str) -> str | None:
+    if not yahoo_ticker:
+        return None
+    ticker = yahoo_ticker.strip()
+    if "." in ticker:
+        base, suffix = ticker.rsplit(".", 1)
+        if suffix.upper() in {"WA", "PL"}:
+            return base.lower()
+    return None
+
+
+def _period_to_offset(period: str | None) -> pd.DateOffset | None:
+    if not period or period == "max":
+        return None
+    if period.endswith("y") and period[:-1].isdigit():
+        return pd.DateOffset(years=int(period[:-1]))
+    if period.endswith("mo") and period[:-2].isdigit():
+        return pd.DateOffset(months=int(period[:-2]))
+    return None
+
+
+def _limit_history(df: pd.DataFrame, *, start: str | None, period: str | None) -> pd.DataFrame:
+    if df.empty:
+        return df
+    out = df.copy()
+    if start:
+        start_ts = pd.to_datetime(start, errors="coerce")
+        if pd.notna(start_ts):
+            out = out.loc[out.index >= start_ts]
+    offset = _period_to_offset(period)
+    if offset is not None and not out.empty:
+        tz = out.index.tz if hasattr(out.index, "tz") else None
+        now = pd.Timestamp.today(tz=tz)
+        cutoff = now - offset
+        out = out.loc[out.index >= cutoff]
+    return out
+
+
+def fetch_stooq_ohlcv(
+    yahoo_ticker: str,
+    *,
+    interval: str = "1wk",
+    start: str | None = None,
+    period: str | None = None,
+) -> pd.DataFrame:
+    symbol = _yahoo_to_stooq_symbol(yahoo_ticker)
+    if not symbol:
+        return pd.DataFrame()
+    freq = STOOQ_INTERVAL_MAP.get(interval, "w")
+    for base in STOOQ_BASE_URLS:
+        url = f"{base}/q/d/l/?s={symbol}&c=0&i={freq}"
+        try:
+            resp = requests.get(url, headers=HEADERS, timeout=15)
+        except Exception:
+            continue
+        if not getattr(resp, "ok", False):
+            continue
+        text = getattr(resp, "text", "")
+        if not text or "Date" not in text:
+            continue
+        try:
+            raw = pd.read_csv(StringIO(text))
+        except Exception:
+            continue
+        if raw.empty or "Date" not in raw.columns:
+            continue
+        raw["Date"] = pd.to_datetime(raw["Date"], errors="coerce")
+        raw = raw.dropna(subset=["Date"]).set_index("Date").sort_index()
+        raw = raw.loc[~raw.index.duplicated(keep="last")]
+        cols = [c for c in ["Open", "High", "Low", "Close"] if c in raw.columns]
+        if len(cols) < 4:
+            continue
+        for col in cols:
+            raw[col] = pd.to_numeric(raw[col], errors="coerce")
+        data = raw[cols].dropna()
+        data = _limit_history(data, start=start, period=period)
+        if not data.empty:
+            return data
+    return pd.DataFrame()
+
 @st.cache_data(ttl=60*60*24, show_spinner=False)
 def get_wig20_hardcoded() -> pd.DataFrame:
     df = pd.DataFrame({"gpw_ticker": sorted(set(WIG20_HC_TICKERS))})
@@ -84,11 +176,15 @@ def load_weekly_ohlcv(yahoo_ticker: str, period: str = "5y") -> pd.DataFrame:
     try:
         df = yf.download(yahoo_ticker, interval="1wk", period=period, auto_adjust=False, progress=False, threads=YF_THREADS)
     except Exception:
-        return pd.DataFrame()
+        df = pd.DataFrame()
     if isinstance(df.columns, pd.MultiIndex):
         df.columns = df.columns.get_level_values(0)
     if not df.empty:
         df = df.dropna(subset=["Open","High","Low","Close"])
+    if df.empty:
+        fallback = fetch_stooq_ohlcv(yahoo_ticker, interval="1wk", period=period)
+        if not fallback.empty:
+            return fallback
     return df
 
 def _extract_single(df: pd.DataFrame) -> pd.DataFrame:
@@ -130,6 +226,11 @@ def load_many_weekly_ohlcv(tickers: list[str], *, period: str = "5y", start: str
                     out[t] = sub; missing.discard(t)
             except Exception:
                 pass
+    if missing:
+        for t in list(missing):
+            fallback = fetch_stooq_ohlcv(t, interval="1wk", start=start, period=period)
+            if not fallback.empty:
+                out[t] = fallback; missing.discard(t)
     # Return dict plus list of failed for UI
     out["__failed__"] = pd.Series(sorted(missing)) if missing else pd.Series([], dtype=str)
     return out
@@ -139,11 +240,15 @@ def load_htf_ohlcv(yahoo_ticker: str, interval: str = "1mo", period: str = "max"
     try:
         df = yf.download(yahoo_ticker, interval=interval, period=period, auto_adjust=False, progress=False, threads=YF_THREADS)
     except Exception:
-        return pd.DataFrame()
+        df = pd.DataFrame()
     if isinstance(df.columns, pd.MultiIndex):
         df.columns = df.columns.get_level_values(0)
     if not df.empty:
         df = df.dropna(subset=["Open","High","Low","Close"])
+    if df.empty:
+        fallback = fetch_stooq_ohlcv(yahoo_ticker, interval=interval, period=period)
+        if not fallback.empty:
+            return fallback
     return df
 
 @st.cache_data(ttl=60*60*12, show_spinner=False)
@@ -178,5 +283,10 @@ def load_many_htf_ohlcv(tickers: list[str], *, interval: str = "1mo", period: st
                     out[t] = sub; missing.discard(t)
             except Exception:
                 pass
+    if missing:
+        for t in list(missing):
+            fallback = fetch_stooq_ohlcv(t, interval=interval, period=period)
+            if not fallback.empty:
+                out[t] = fallback; missing.discard(t)
     out["__failed__"] = pd.Series(sorted(missing)) if missing else pd.Series([], dtype=str)
     return out

--- a/tests/test_crt_core.py
+++ b/tests/test_crt_core.py
@@ -1,28 +1,260 @@
 # -*- coding: utf-8 -*-
-import pandas as pd, numpy as np
+import math
+import pandas as pd, numpy as np, pytest
 from crt_core import crt_scan, get_key_level_and_confluence, midline
+
 
 def _weekly_df():
     idx = pd.date_range("2024-01-05", periods=8, freq="W-FRI")
-    data = {"Open":[10,10.5,10,10.2,9.8,9.4,9.6,9.7],
-            "High":[11,11.2,10.8,10.6,10,9.9,10.2,10.1],
-            "Low":[9,10,9.6,9.7,9.2,9.0,9.3,9.4],
-            "Close":[10,10.1,10.2,10,9.9,9.6,9.8,9.9]}
+    data = {
+        "Open": [10, 10.5, 10, 10.2, 9.8, 9.4, 9.6, 9.7],
+        "High": [11, 11.2, 10.8, 10.6, 10, 9.9, 10.2, 10.1],
+        "Low": [9, 10, 9.6, 9.7, 9.2, 9.0, 9.3, 9.4],
+        "Close": [10, 10.1, 10.2, 10, 9.9, 9.6, 9.8, 9.9],
+    }
     return pd.DataFrame(data, index=idx)
 
-def test_midline(): assert midline(10,12)==11.0
 
-def test_crt_scan_small_lookback():
-    d=_weekly_df()
+def _make_weekly(rows, start="2024-01-05"):
+    idx = pd.date_range(start, periods=len(rows), freq="W-FRI")
+    df = pd.DataFrame(rows, columns=["Open", "High", "Low", "Close"], index=idx)
+    return df
+
+
+def test_midline():
+    assert midline(10, 12) == 11.0
+
+
+def test_crt_scan_small_lookback_returns_list():
+    d = _weekly_df()
     setups = crt_scan(d, lookback_bars=3, confirm_within=2, confirm_method="high")
     assert isinstance(setups, list)
 
+
+def test_crt_scan_detects_bullish_setup_with_confirmation():
+    rows = [
+        [10, 11, 9.5, 10.5],  # noise
+        [10, 12, 10, 11],  # C1
+        [9.2, 11.5, 8.8, 11.0],  # C2 sweep low, close in range
+        [11.2, 12.6, 10.8, 12.4],  # C3 high > C1H (confirmation)
+        [11.0, 11.8, 10.9, 11.2],  # trailing bar without new sweep
+    ]
+    df = _make_weekly(rows)
+
+    setups = crt_scan(
+        df,
+        lookback_bars=10,
+        confirm_within=2,
+        confirm_method="high",
+        directions=("bullish",),
+    )
+
+    assert len(setups) == 1
+    rec = setups[0]
+    assert rec["direction"] == "BULL"
+    assert rec["swept_side"] == "LOW"
+    assert rec["confirmed"] is True
+    assert rec["c3_happened"] is True
+    assert rec["confirm_rule"] == "high>C1H in 2"
+    assert rec["C3_date_within"] == df.index[3]
+    assert rec["C3_date_any"] == df.index[3]
+    assert pytest.approx(rec["C1_mid"], rel=0.01) == 11.0
+    assert pytest.approx(rec["C2_position_in_range"], rel=0.01) == 0.5
+
+
+def test_crt_scan_bearish_c3_outside_window_marks_any_only():
+    rows = [
+        [110, 112, 105, 111],
+        [112, 125, 110, 118],  # C1
+        [118, 130, 115, 120],  # C2 sweeps high, closes inside
+        [117, 123, 108, 111],  # inside window but no confirm (close >= C1L)
+        [110, 121, 103, 108],  # confirmation happens after window
+        [108, 115, 95, 96],  # drop below C1L -> C3_any only
+    ]
+    df = _make_weekly(rows)
+
+    setups = crt_scan(
+        df,
+        lookback_bars=10,
+        confirm_within=1,
+        confirm_method="close",
+        directions=("bearish",),
+    )
+
+    assert len(setups) == 1
+    rec = setups[0]
+    assert rec["direction"] == "BEAR"
+    assert rec["swept_side"] == "HIGH"
+    assert rec["confirmed"] is False
+    assert rec["c3_happened"] is True
+    assert rec["confirm_rule"] == "close<C1L in 1"
+    assert pd.isna(rec["C3_date_within"])
+    assert rec["C3_date_any"] == df.index[4]
+
+
+def test_crt_scan_respects_midline_and_strict_flags():
+    rows = [
+        [9.0, 9.8, 8.7, 9.5],  # filler
+        [9.5, 10.2, 9.1, 9.9],  # filler
+        [10, 12, 10, 11],  # C1
+        [9, 11, 8.5, 10.4],  # C2 close below midline (11)
+        [9.5, 12.5, 9.3, 12.3],
+    ]
+    df = _make_weekly(rows)
+
+    setups_default = crt_scan(df, lookback_bars=5, directions=("bullish",))
+    assert len(setups_default) == 1
+
+    setups_midline = crt_scan(
+        df,
+        lookback_bars=5,
+        directions=("bullish",),
+        require_midline=True,
+    )
+    assert setups_midline == []
+
+    # Same data but tweak C2 close to fail strict_vs_c1open when enabled
+    rows_strict = [
+        [9.0, 9.8, 8.7, 9.5],
+        [9.5, 10.2, 9.1, 9.9],
+        [12, 12.5, 10, 12],  # C1 with open above C2 close
+        [9.5, 11.5, 9, 11.0],  # C2 close < C1 open
+        [11.5, 13.0, 10.8, 12.8],
+    ]
+    df_strict = _make_weekly(rows_strict)
+    setups_relaxed = crt_scan(df_strict, lookback_bars=5, directions=("bullish",))
+    assert len(setups_relaxed) == 1
+    setups_strict = crt_scan(
+        df_strict,
+        lookback_bars=5,
+        directions=("bullish",),
+        strict_vs_c1open=True,
+    )
+    assert setups_strict == []
+
+
+def test_crt_scan_lookback_limits_old_setups():
+    rows = [
+        [10, 12, 10, 11],
+        [9, 11, 8.5, 11],  # first setup candidate
+        [11, 13, 11, 12],
+        [10, 11, 9, 10],  # later C1
+        [8.5, 10.5, 8, 10.2],  # later C2 within lookback
+    ]
+    df = _make_weekly(rows)
+
+    setups_all = crt_scan(df, lookback_bars=10, directions=("bullish",))
+    assert len(setups_all) == 2
+
+    setups_short = crt_scan(df, lookback_bars=2, directions=("bullish",))
+    assert len(setups_short) == 1
+    assert setups_short[0]["C2_date"] == df.index[4]
+
+
 def test_key_level_touch_bull():
-    idx = pd.date_range("2023-01-31", periods=12, freq="M")
-    htf=pd.DataFrame({"Open":np.linspace(10,9,len(idx)),
-                      "High":np.linspace(11,12,len(idx)),
-                      "Low":np.linspace(9,8,len(idx)),
-                      "Close":np.linspace(10,9.5,len(idx))}, index=idx)
-    tf, kl, kd, conf = get_key_level_and_confluence(htf, pd.to_datetime("2023-12-29"), "BULL",
-        9.2, 10.0, 9.0, 9.9, 6, "C1 lub C2", "touch (≤, ≥)", "1mo")
-    assert tf in ("1M","3M") and isinstance(kl, float)
+    idx = pd.date_range("2023-01-31", periods=12, freq="ME")
+    htf = pd.DataFrame(
+        {
+            "Open": np.linspace(10, 9, len(idx)),
+            "High": np.linspace(11, 12, len(idx)),
+            "Low": np.linspace(9, 8, len(idx)),
+            "Close": np.linspace(10, 9.5, len(idx)),
+        },
+        index=idx,
+    )
+    tf, kl, kd, conf = get_key_level_and_confluence(
+        htf,
+        pd.to_datetime("2023-12-29"),
+        "BULL",
+        9.2,
+        10.0,
+        9.0,
+        9.9,
+        6,
+        "C1 lub C2",
+        "touch (≤, ≥)",
+        "1mo",
+    )
+    assert tf == "1M"
+    assert isinstance(kl, float)
+    assert kd in htf.index
+    assert conf is True
+
+
+def test_key_level_strict_directional_filter():
+    idx = pd.date_range("2023-01-31", periods=4, freq="ME")
+    htf = pd.DataFrame(
+        {
+            "Open": [100, 101, 102, 103],
+            "High": [105, 106, 107, 108],
+            "Low": [98, 99.5, 100.5, 101],
+            "Close": [101, 101.5, 102.5, 103],
+        },
+        index=idx,
+    )
+    tf, key_val, _, conf = get_key_level_and_confluence(
+        htf,
+        idx[-1],
+        "BULL",
+        101.6,
+        104.2,
+        100.0,
+        104.0,
+        6,
+        "Tylko C1",
+        "strict (<, >)",
+        "1mo",
+    )
+    assert tf == "1M"
+    assert math.isclose(key_val, 101.5, rel_tol=1e-6)
+    assert conf is False  # fails directional rule (C1 low > key)
+
+
+def test_key_level_prefers_closest_candidate_between_c1_and_c2():
+    idx = pd.date_range("2023-01-31", periods=5, freq="ME")
+    htf = pd.DataFrame(
+        {
+            "Open": [300, 280, 260, 240, 220],
+            "High": [305, 285, 265, 245, 225],
+            "Low": [295, 275, 255, 100, 90],
+            "Close": [298, 278, 258, 102, 95],
+        },
+        index=idx,
+    )
+    tf, key_val, _, conf = get_key_level_and_confluence(
+        htf,
+        idx[-1],
+        "BULL",
+        310.0,
+        330.0,
+        99.0,
+        118.0,
+        9,
+        "C1 lub C2",
+        "touch (≤, ≥)",
+        "1mo",
+    )
+    assert tf == "1M"
+    # The closest HTF level to the C2 low (99) is ~100 from recent bars
+    assert math.isclose(key_val, 100.0, rel_tol=1e-6)
+    assert conf is True
+
+
+def test_key_level_handles_missing_history():
+    tf, key_val, key_date, conf = get_key_level_and_confluence(
+        pd.DataFrame(),
+        pd.to_datetime("2024-01-01"),
+        "BULL",
+        0,
+        0,
+        0,
+        0,
+        6,
+        "C1 lub C2",
+        "touch (≤, ≥)",
+        "1mo",
+    )
+    assert tf == "1M"
+    assert math.isnan(key_val)
+    assert pd.isna(key_date)
+    assert conf is False

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -12,6 +12,85 @@ def test_load_many_weekly_ohlcv_multi(monkeypatch):
     out = data_io.load_many_weekly_ohlcv(["AAA","BBB"], period="2y")
     assert set(out.keys()) >= {"AAA","BBB"}
 
+def test_load_many_weekly_ohlcv_reports_missing(monkeypatch):
+    idx = pd.date_range("2024-01-05", periods=4, freq="W-FRI")
+    cols = MultiIndex.from_product([["AAA"], ["Open","High","Low","Close"]])
+    df = pd.DataFrame(np.random.rand(len(idx), len(cols)), index=idx, columns=cols)
+
+    def fake_download(tickers, *args, **kwargs):
+        assert sorted(tickers) == ["AAA", "BBB"]
+        return df
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    out = data_io.load_many_weekly_ohlcv(["AAA", "BBB"], period="1y", retries=0)
+    assert "AAA" in out and isinstance(out["AAA"], pd.DataFrame)
+    assert "BBB" not in out
+    assert "BBB" in out["__failed__"].tolist()
+
+
+def test_load_many_weekly_ohlcv_bulk_retry(monkeypatch):
+    idx = pd.date_range("2024-01-05", periods=3, freq="W-FRI")
+    base = pd.DataFrame(
+        {
+            "Open": np.linspace(10, 12, len(idx)),
+            "High": np.linspace(11, 13, len(idx)),
+            "Low": np.linspace(9, 11, len(idx)),
+            "Close": np.linspace(10, 12, len(idx)),
+        },
+        index=idx,
+    )
+    calls: list[str] = []
+
+    def fake_download(tickers, *args, **kwargs):
+        if isinstance(tickers, list):
+            raise RuntimeError("bulk fail")
+        calls.append(tickers)
+        return base
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    out = data_io.load_many_weekly_ohlcv(["AAA", "BBB"], period="2y", retries=2)
+    assert set(out.keys()) >= {"AAA", "BBB", "__failed__"}
+    assert sorted(calls) == ["AAA", "BBB"]
+    for ticker in ["AAA", "BBB"]:
+        assert isinstance(out[ticker], pd.DataFrame)
+        pd.testing.assert_index_equal(out[ticker].index, idx)
+
+
+def test_load_many_weekly_single_ticker(monkeypatch):
+    idx = pd.date_range("2024-01-05", periods=3, freq="W-FRI")
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2, 3],
+            "High": [2, 3, 4],
+            "Low": [0.5, 1.5, 2.5],
+            "Close": [1.5, 2.5, 3.5],
+        },
+        index=idx,
+    )
+
+    def fake_download(tickers, *args, **kwargs):
+        assert tickers == ["AAA"]
+        return df
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    out = data_io.load_many_weekly_ohlcv(["AAA"], period="1y")
+    assert "AAA" in out and isinstance(out["AAA"], pd.DataFrame)
+    assert out["__failed__"].empty
+
+
+def test_load_many_htf_multi(monkeypatch):
+    idx = pd.date_range("2023-01-31", periods=3, freq="ME")
+    cols = MultiIndex.from_product([["AAA"], ["Open", "High", "Low", "Close"]])
+    df = pd.DataFrame(np.random.rand(len(idx), len(cols)), index=idx, columns=cols)
+
+    def fake_download(tickers, *args, **kwargs):
+        return df
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    out = data_io.load_many_htf_ohlcv(["AAA"], interval="1mo", period="max")
+    assert "AAA" in out and isinstance(out["AAA"], pd.DataFrame)
+
+
 def test_stringio_read_html(monkeypatch):
     import requests
     html = "<table><tr><th>Symbol</th><th>Name</th></tr><tr><td>AAA</td><td>Alpha</td></tr></table>"
@@ -21,3 +100,81 @@ def test_stringio_read_html(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     df = data_io.fetch_wiki_table(["http://example.com"], "IDX")
     assert "yahoo_ticker" in df.columns or df.empty
+
+
+def test_fetch_wiki_table_returns_empty_on_failure(monkeypatch):
+    import requests
+
+    def fake_get(url, headers=None, timeout=20):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    data_io.fetch_wiki_table.clear()
+    df = data_io.fetch_wiki_table(["http://example.com"], "IDX")
+    assert df.empty
+
+
+def test_load_many_weekly_ohlcv_stooq_fallback(monkeypatch):
+    data_io.load_many_weekly_ohlcv.clear()
+
+    def fake_download(*args, **kwargs):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "download", fake_download)
+
+    csv = """Date,Open,High,Low,Close,Volume\n2023-12-22,10,11,9,10.5,1000\n2024-01-05,11,12,10,11.5,1200\n"""
+
+    class FakeResp:
+        ok = True
+
+        def __init__(self, text):
+            self.text = text
+
+    calls: list[str] = []
+
+    def fake_get(url, headers=None, timeout=15):
+        calls.append(url)
+        return FakeResp(csv)
+
+    monkeypatch.setattr(data_io.requests, "get", fake_get)
+
+    out = data_io.load_many_weekly_ohlcv(["ALE.WA", "CDR.WA"], start="2024-01-01", period="5y", retries=0)
+
+    assert set(out.keys()) >= {"ALE.WA", "CDR.WA", "__failed__"}
+    assert calls  # ensure fallback attempted
+    for ticker in ["ALE.WA", "CDR.WA"]:
+        df = out[ticker]
+        assert not df.empty
+        assert (df.index >= pd.Timestamp("2024-01-01")).all()
+        assert list(df.columns) == ["Open", "High", "Low", "Close"]
+    assert out["__failed__"].empty
+
+
+def test_load_many_htf_ohlcv_stooq_fallback(monkeypatch):
+    data_io.load_many_htf_ohlcv.clear()
+
+    def fake_download(*args, **kwargs):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "download", fake_download)
+
+    csv = """Date,Open,High,Low,Close,Volume\n2024-01-31,100,110,95,108,10000\n2024-02-29,108,120,100,115,9000\n"""
+
+    class FakeResp:
+        ok = True
+
+        def __init__(self, text):
+            self.text = text
+
+    def fake_get(url, headers=None, timeout=15):
+        return FakeResp(csv)
+
+    monkeypatch.setattr(data_io.requests, "get", fake_get)
+
+    out = data_io.load_many_htf_ohlcv(["PKN.WA"], interval="1mo", period="max", retries=0)
+
+    assert set(out.keys()) >= {"PKN.WA", "__failed__"}
+    df = out["PKN.WA"]
+    assert not df.empty
+    assert list(df.columns) == ["Open", "High", "Low", "Close"]
+    assert out["__failed__"].empty

--- a/tests/test_tv_chart.py
+++ b/tests/test_tv_chart.py
@@ -5,9 +5,17 @@ from tv_chart import yahoo_to_tv_symbol, tradingview_embed_html, build_plotly_ch
 def test_symbol_map_pl():
     assert yahoo_to_tv_symbol("PKN.WA") == "GPW:PKN"
 
+def test_symbol_map_trims_and_uppercases():
+    assert yahoo_to_tv_symbol("  msft ") == "MSFT"
+
 def test_tv_html_contains_symbol():
     html = tradingview_embed_html("GPW:PKN", height=400, interval="D")
     assert "GPW:PKN" in html and "tv.js" in html
+
+def test_tv_html_invalid_height_defaults():
+    html = tradingview_embed_html("GPW:PKN", height=-10, interval="w")
+    assert "height:520px" in html
+    assert "interval: 'W'" in html
 
 def test_build_plotly_chart_annotations():
     idx = pd.date_range("2024-01-01", periods=10, freq="D")
@@ -18,3 +26,16 @@ def test_build_plotly_chart_annotations():
     rec = {"Kierunek":"BULL","Stop":1.0,"TP1":6.0,"TP2":8.0,"KeyLevel":0.9,"C2":"2024-01-07"}
     fig = build_plotly_chart(daily, rec, "TEST")
     assert len(fig.layout.annotations) >= 1 and hasattr(fig.layout, "shapes")
+
+
+def test_build_plotly_chart_bearish_annotation():
+    idx = pd.date_range("2024-02-01", periods=5, freq="D")
+    daily = pd.DataFrame({
+        "Open": [10, 11, 12, 13, 14],
+        "High": [11, 12, 13, 14, 15],
+        "Low": [9, 10, 11, 12, 13],
+        "Close": [10.5, 11.5, 12.5, 13.5, 14.5],
+    }, index=idx)
+    rec = {"Kierunek": "BEAR", "C2": idx[2].date()}
+    fig = build_plotly_chart(daily, rec, "TST")
+    assert any("BEAR" in ann.text for ann in fig.layout.annotations)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -10,3 +10,30 @@ def test_alias_map_applied():
 def test_parse_us_passthrough():
     df = parse_us_tickers("AAPL, MSFT")
     assert df.loc[0, "yahoo_ticker"] == "AAPL"
+
+
+def test_parse_gpw_tickers_preserves_prefix_and_suffix():
+    raw = " ^wig20 , pkn.wa ,  xyz "
+    df = parse_gpw_tickers(raw)
+    vals = df["yahoo_ticker"].tolist()
+    assert "^WIG20" in vals
+    assert "PKN.WA" in vals
+    assert "XYZ.WA" in vals
+
+
+def test_build_universe_df_combines_sources(monkeypatch):
+    import universe
+
+    fake_wig_all = pd.DataFrame({"company": ["AAA"], "yahoo_ticker": ["AAA.WA"], "group": ["WIG"]})
+    fake_wig20 = pd.DataFrame({"company": ["BBB"], "yahoo_ticker": ["BBB.WA"], "group": ["WIG20"]})
+    fake_mwig40 = pd.DataFrame({"company": ["CCC"], "yahoo_ticker": ["CCC.WA"], "group": ["mWIG40"]})
+    fake_sp = pd.DataFrame({"company": ["DDD"], "yahoo_ticker": ["DDD"], "group": ["S&P500"]})
+
+    monkeypatch.setattr(universe, "get_wig_all", lambda: fake_wig_all)
+    monkeypatch.setattr(universe, "get_wig20_hardcoded", lambda: fake_wig20)
+    monkeypatch.setattr(universe, "get_mwig40_hardcoded", lambda: fake_mwig40)
+    monkeypatch.setattr(universe, "fetch_sp500_companies", lambda: fake_sp)
+
+    df = build_universe_df(True, True, True, True, "DIN", "AAPL")
+    assert set(df["yahoo_ticker"]) == {"AAA.WA", "BBB.WA", "CCC.WA", "DDD", "DNP.WA", "AAPL"}
+    assert df["Active"].all()


### PR DESCRIPTION
## Summary
- add Stooq-based OHLC fetch helper for Warsaw tickers and integrate it into weekly/HTF loaders as a fallback when Yahoo data is missing
- trim fallback history to requested ranges and ensure multi-ticker loaders retry with Stooq data before reporting failures
- cover the new fallback flows with unit tests for weekly and HTF batch loaders

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c85c1a3c9c8327ae4035eef561200d